### PR TITLE
Fountain library update and visual changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@codemirror/lang-javascript": "^0.18.0",
                 "@types/codemirror": "^0.0.98",
                 "codemirror": "^5.60.0",
+                "fountain-js": "^1.0.0",
                 "obsidian": "obsidianmd/obsidian-api#master",
                 "rollup-plugin-styles": "^3.14.1",
                 "tslib": "2.1.0"
@@ -3589,10 +3590,12 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
             "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
-            "funding": [{
-                "type": "github",
-                "url": "https://github.com/sponsors/fb55"
-            }]
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ]
         },
         "node_modules/domelementtype": {
             "version": "1.3.1",
@@ -4479,6 +4482,11 @@
             "engines": {
                 "node": ">= 0.12"
             }
+        },
+        "node_modules/fountain-js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fountain-js/-/fountain-js-1.0.0.tgz",
+            "integrity": "sha512-WURsxp+ciH4zczdjNEGH06D8eVGlw3TDVyXiYZkeVJrQgmrrxlrKIm30TsPNgLELuFF9kYqZK+ft+ye1jcFgPQ=="
         },
         "node_modules/fragment-cache": {
             "version": "0.2.1",
@@ -10549,7 +10557,8 @@
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
             "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "github",
                     "url": "https://github.com/sponsors/feross"
                 },
@@ -11002,7 +11011,8 @@
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "github",
                     "url": "https://github.com/sponsors/feross"
                 },
@@ -11446,7 +11456,8 @@
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
             "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "github",
                     "url": "https://github.com/sponsors/feross"
                 },
@@ -16855,6 +16866,11 @@
                 "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
             }
+        },
+        "fountain-js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fountain-js/-/fountain-js-1.0.0.tgz",
+            "integrity": "sha512-WURsxp+ciH4zczdjNEGH06D8eVGlw3TDVyXiYZkeVJrQgmrrxlrKIm30TsPNgLELuFF9kYqZK+ft+ye1jcFgPQ=="
         },
         "fragment-cache": {
             "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "@codemirror/lang-javascript": "^0.18.0",
         "@types/codemirror": "^0.0.98",
         "codemirror": "^5.60.0",
+        "fountain-js": "^1.0.0",
         "obsidian": "obsidianmd/obsidian-api#master",
         "rollup-plugin-styles": "^3.14.1",
         "tslib": "2.1.0"

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,8 @@ class FountainView extends TextFileView {
 			lineNumbers: false,
 			lineWrapping: true,
 			scrollbarStyle: null,
-			keyMap: "default"
+			keyMap: "default",
+			theme: "fountain"
 		});
 		this.render = this.render.bind(this);
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,17 +4,23 @@ import { Fountain } from 'fountain-js'
 
 function parseFountain(text: string, container: HTMLElement) {
 	const { html } = new Fountain().parse(text);
+
+	// Renders pages individually as if they were printed.
+	// DPI can be changed to 72, 100, or 150.
 	const pages = container.createDiv({
-		cls: "us-letter dpi72"
+		cls: "us-letter dpi100"
 	})
 	pages.id = "script"
 
+	// Adds title page if found.
 	if (html.title_page) {
 		const titlePage = pages.createDiv({
 			cls: "page title-page"
 		})
 		titlePage.innerHTML = html.title_page;
 	}
+	
+	// Adds all script pages.
 	const script = pages.createDiv({
 		cls: "page"
 	})

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,24 @@
 import { Plugin, WorkspaceLeaf, TextFileView, setIcon } from 'obsidian';
 import * as CodeMirror from 'codemirror';
-import * as fountain from '../node_modules/Fountain-js/fountain.js';
+import { Fountain } from 'fountain-js'
 
 function parseFountain(text: string, container: HTMLElement) {
-	fountain.parse(text, function (output) {
-		container.innerHTML = output.html.script;
-	});
+	const { html } = new Fountain().parse(text);
+	const pages = container.createDiv({
+		cls: "us-letter dpi72"
+	})
+	pages.id = "script"
+
+	if (html.title_page) {
+		const titlePage = pages.createDiv({
+			cls: "page title-page"
+		})
+		titlePage.innerHTML = html.title_page;
+	}
+	const script = pages.createDiv({
+		cls: "page"
+	})
+	script.innerHTML = html.script;
 }
 
 export default class FountainPlugin extends Plugin {

--- a/styles.css
+++ b/styles.css
@@ -6,7 +6,7 @@
 }
 
 .cm-s-fountain {
-    font-family: "PT Mono","Menlo",monospace;
+    font-family: var(--font-monospace)
 }
 
 .screenplay {

--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,10 @@
     position: unset;
 }
 
+.cm-s-fountain {
+    font-family: "PT Mono","Menlo",monospace;
+}
+
 .screenplay {
     display: block;
 }

--- a/styles.css
+++ b/styles.css
@@ -6,89 +6,135 @@
 }
 
 .screenplay {
-    margin: 0;
-    padding: 0;
-    border: 0;
-    font-size: 100%;
-    font: inherit;
-    overflow-y: hidden;
-    vertical-align: baseline;
-}
-
-.screenplay {
     display: block;
 }
 
+/* Screenplay */
+/* #51445F - moon warrior */ 
+.screenplay #script { margin: 25px auto 0 auto; width: 850px; }
 
-/* Styles for Screenplain */
-
-.screenplay {
-    margin: auto;
-    width: 60%;
+.screenplay .page::-moz-selection, .screenplay .page::selection { background: #ED303C; color: #fff; }
+.screenplay #script .page
+{    
+    background: #fff;
+    border: 1px solid #d2d2d2;
+    border-radius: 2px;
+    color: #222;
+    cursor: text;
+    font: Courier,"Courier New",monospace;
+    letter-spacing: 0 !important;
+    font-family: 'Courier Final Draft', Courier, Courier New, monospace;
+    line-height: 107.5%;
+    margin-bottom: 25px;
+    position: relative;
     text-align: left;
-    font: 12pt 'Courier Final Draft', 'Courier Screenplay', Courier;
-    padding: 0pt 0 0 0pt;
-    position: static;
+    width: 100%;
+    z-index: 200;
+    -webkit-box-shadow: 0 0 5px rgba(0,0,0,0.1);
+	-moz-box-shadow: 0 0 5px rgba(0,0,0,0.1);
+	box-shadow: 0 0 5px rgba(0,0,0,0.1);
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;    
 }
 
-.screenplay>header {
-    margin-bottom: 1em;
-    border-bottom: 1px solid black;
-}
+.screenplay #script.dpi72 .page { font-size: 12px; padding: 72px 72px 72px 108px; }
+.screenplay #script.dpi100 .page { font-size: 16px; padding: 100px 100px 100px 150px; }
+.screenplay #script.dpi150 .page { font-size: 33px;  padding: 150px 150px 150px 225px; }
 
-.screenplay>footer {
-    margin-top: 1em;
-}
+.screenplay #script.dpi72 .page h1,
+.screenplay #script.dpi72 .page h2,
+.screenplay #script.dpi72 .page h3,
+.screenplay #script.dpi72 .page h4,
+.screenplay #script.dpi72 .page p { font-size: 12px; font-weight: normal; }
 
-.screenplay>em {
-    font-style: italic;
-}
+.screenplay #script.dpi100 .page h1,
+.screenplay #script.dpi100 .page h2,
+.screenplay #script.dpi100 .page h3,
+.screenplay #script.dpi100 .page h4,
+.screenplay #script.dpi100 .page p { font-size: 17px; font-weight: normal; }
 
-.screenplay>p .bold {
-    font-weight: bold;
-}
+.screenplay #script.dpi150 .page h1,
+.screenplay #script.dpi150 .page h2,
+.screenplay #script.dpi150 .page h3,
+.screenplay #script.dpi150 .page h4,
+.screenplay #script.dpi150 .page p { font-size: 33px; font-weight: normal; }
 
-.screenplay>br {
-    clear: both;
-}
+/* US Paper */
+.screenplay #script.us-letter.dpi72 { width: 612px; } /* us letter - 72 dpi - 612px x 792px - margins: 1" 1" 1" 1.5" */
+.screenplay #script.us-letter.dpi100 { width: 850px; } /* us letter - 100 dpi - 850px x 1100px - margins: 1" 1" 1" 1.5" */
+.screenplay #script.us-letter.dpi150 { width: 1275px; } /* us letter - 150 dpi - 1275px x 1650px - margins: 1" 1" 1" 1.5" */
 
-.screenplay>div.action p {
-    margin-top: 1em;
-}
+.screenplay #script.us-letter.dpi72 .page { min-height: 792px; } /* min height temporary until proper paging is implemented */
+.screenplay #script.us-letter.dpi100 .page { min-height: 1100px; } /* min height temporary until proper paging is implemented */
+.screenplay #script.us-letter.dpi150 .page { min-height: 1650px; } /* min height temporary until proper paging is implemented */
 
+.screenplay #script.us-letter.dpi72 .page.title-page { height: 792px; } /* temp for title page until paging is implemented */
+.screenplay #script.us-letter.dpi100 .page.title-page { height: 1100px; } /* temp for title page until paging is implemented */
+.screenplay #script.us-letter.dpi150 .page.title-page { height: 1650px; } /* temp for title page until paging is implemented */
 
-/* Dialogue */
+/* A4 Paper */
+.screenplay #script.a4.dpi72 { width: 595px; } /* us letter - 72 dpi - 595px x 842px - margins: 1" 1" 1" 1.5" */
+.screenplay #script.a4.dpi100 { width: 827px; } /* us letter - 72 dpi - 827px x 1169px - margins: 1" 1" 1" 1.5" */
+.screenplay #script.a4.dpi150 {  width: 1250px; } /* us letter - 72 dpi - 1250px x 1754px - margins: 1" 1" 1" 1.5" */
 
-.screenplay>.dialogue h4 {
-    text-align: center;
-    color: var(--bright-yellow) !important;
-    font-weight: 500 !important;
-    font-size: 18px !important;
-}
+.screenplay #script.a4.dpi72 .page { height: 842px; }
+.screenplay #script.a4.dpi100 .page { height: 1169px; }
+.screenplay #script.a4.dpi150 .page { height: 1754px; }
 
-.screenplay>.dialogue p {
-    text-align: left;
-    margin-left: 20%;
-}
+/* title page */
+.screenplay #script .title-page h1 { margin-top: 50%; margin-bottom: 34px; text-align: center; width: 90.5%; }
+.screenplay #script .title-page p.credit { text-align: center; width: 90.5%; }
+.screenplay #script .title-page p.author,
+.screenplay #script .title-page p.authors { margin-bottom: 32px; margin-top: 0; text-align: center; width: 90.5%; }
+.screenplay #script .title-page p.source { margin-bottom: 32px; text-align: center; width: 90.5%; }
+.screenplay #script .title-page p.notes { bottom: 350px; position: absolute; right: 0; text-align: right; }
+.screenplay #script.dpi72 .title-page p.notes { bottom: 252px; right: 72px; }
+.screenplay #script.dpi100 .title-page p.notes { bottom: 350px; right: 100px; }
+.screenplay #script.dpi150 .title-page p.notes { bottom: 525px; right: 150px; }
+.screenplay #script .title-page p.date,
+.screenplay #script .title-page p.draft-date { bottom: 250px; position: absolute; right: 0; text-align: right; }
+.screenplay #script.dpi72 .title-page p.date,
+.screenplay #script.dpi72 .title-page p.draft-date { bottom: 180px; right: 72px; }
+.screenplay #script.dpi100 .title-page p.date,
+.screenplay #script.dpi100 .title-page p.draft-date { bottom: 250px; right: 100px; }
+.screenplay #script.dpi150 .title-page p.date,
+.screenplay #script.dpi150 .title-page p.draft-date { bottom: 375px; right: 150px; }
+.screenplay #script .title-page p.contact { bottom: 100px; position: absolute; right: 0; text-align: right; }
+.screenplay #script.dpi72 .title-page p.contact { bottom: 72px; right: 72px; }
+.screenplay #script.dpi100 .title-page p.contact { bottom: 100px; right: 100px; }
+.screenplay #script.dpi150 .title-page p.contact { bottom: 150px; right: 150px; }
+.screenplay #script .title-page p.copyright { bottom: 100px; position: absolute; text-align: left; }
+.screenplay #script.dpi72 .title-page p.copyright { bottom: 72px; }
+.screenplay #script.dpi100 .title-page p.copyright { bottom: 100px; }
+.screenplay #script.dpi150 .title-page p.copyright { bottom: 150px; }
 
-.underline {
-    text-decoration: underline;
-}
+/* script */
+.screenplay #script .page h2 { text-align: right; }
+.screenplay #script .page h2.left-aligned { text-align: left }
+.screenplay #script .page h3 { position: relative; }
+.screenplay #script .page h3:before { color: #bbb; content: attr(id); font-weight: bold; left: -45px; position: absolute; }
+.screenplay #script .page h3:after { color: #bbb; content: attr(id); font-weight: bold; right: -45px; position: absolute; }
 
-.screenplay>.dialogue .parenthetical {
-    padding-left: 10%;
-}
+.screenplay #script .page div.dialogue { margin-left: auto; margin-right: auto; width: 68%; }
+.screenplay #script .page div.dialogue h4 { margin-bottom: 0; margin-left: 23%; }
+.screenplay #script .page div.dialogue p.parenthetical { margin-bottom: 0; margin-top: 0; margin-left: 11%;}
+.screenplay #script .page div.dialogue p { margin-bottom: 0; margin-top: 0; }
 
+.screenplay #script .page div.dual-dialogue { margin: 2em 0 0.9em 2%; width: 95%; }
+.screenplay #script .page div.dual-dialogue div.dialogue { display: inline-block; margin: 0; width: 45%; }
+.screenplay #script .page div.dual-dialogue div.dialogue h4 { margin-top: 0;}
+.screenplay #script .page div.dual-dialogue div.dialogue.right { float: right; }
 
-/* Headers */
+.screenplay #script .page p { }
+.screenplay #script .page p.centered { text-align: center; width: 92.5%; }
 
-.screenplay>h3 {
-    margin-top: 2em;
-    text-transform: uppercase;
-    font-weight: bold !important;
-    color: var(--text-accent) !important;
-}
+.screenplay #script .page p.section { color: #bbb; margin-left: -30px; }
+.screenplay #script .page p.synopsis { color: #bbb; margin-left: -20px; }
 
+.screenplay #script .page span.italic { font-style: italic; }
+.screenplay #script .page span.bold { font-weight: bold; }
+.screenplay #script .page span.underline { text-decoration: underline; }
 
 /* Change mode button */
 


### PR DESCRIPTION
- Change Fountain library to `fountain-js`.
- Show screenplay with title page and script pages in reading mode.
- Use monospace from Obsidian settings in editing mode (for Fountain files).